### PR TITLE
Test dao builder view functions get_dao and get_dao_by_address

### DIFF
--- a/contract/src/dao_builder.cairo
+++ b/contract/src/dao_builder.cairo
@@ -35,6 +35,15 @@ pub trait IDaoBuilder<TContractState> {
     // Get total number of DAOs in existence.
     fn get_dao_count(self: @TContractState) -> u32;
 
+    // Get the current creation state of the DAO builder.
+    fn get_dao_creation_state(self: @TContractState) -> DAOCreationState;
+
+    // Get the core hash of the DAO builder.
+    fn get_core_hash(self: @TContractState) -> ClassHash;
+
+    // Get the owner of the DAO builder.
+    fn get_owner(self: @TContractState) -> ContractAddress;
+
     // Pick one implementation for fetching details of a given DAO.
     // fn get_dao_by_index(self: @TContractState, index: felt252) -> DAO;
     fn get_dao_by_address(self: @TContractState, address: ContractAddress) -> DAO;
@@ -166,6 +175,20 @@ pub mod DaoBuilder {
         // Get total number of DAOs in existence.
         fn get_dao_count(self: @ContractState) -> u32 {
             self.dao_count.read()
+        }
+
+        // Get the current creation state of the DAO builder.
+        fn get_dao_creation_state(self: @ContractState) -> DAOCreationState {
+            self.dao_creation_state.read()
+        }
+
+        fn get_core_hash(self: @ContractState) -> ClassHash {
+            self.core_hash.read()
+        }
+
+        fn get_owner(self: @ContractState) -> ContractAddress {
+            self.ownable.assert_only_owner();
+            self.ownable.owner()
         }
 
         // Pick one implementation for fetching details of a given DAO.

--- a/contract/src/dao_builder.cairo
+++ b/contract/src/dao_builder.cairo
@@ -3,8 +3,8 @@
 // Anyone can call this contract to instantiate a new DAO and sub-committee/manager roles can be
 // assigned by the DAO Owner in the DAO Core contract.
 // DAO builder is the hub for inspecting overall and individual profile of deployed DAOs.
-use starknet::class_hash::ClassHash;
 use starknet::ContractAddress;
+use starknet::class_hash::ClassHash;
 
 #[derive(Copy, Drop, Serde, starknet::Store)]
 pub struct DAO {
@@ -55,16 +55,15 @@ pub trait IDaoBuilder<TContractState> {
 
 #[starknet::contract]
 pub mod DaoBuilder {
-    use starknet::event::EventEmitter;
-    use starknet::SyscallResultTrait;
-    use super::{DAO, ContractAddress, IDaoBuilder, DAOCreationState};
-    use starknet::storage::{
-        Map, StoragePointerReadAccess, StoragePointerWriteAccess, StoragePathEntry,
-    };
     use openzeppelin::access::ownable::OwnableComponent;
     use starknet::class_hash::ClassHash;
-    use starknet::syscalls::{deploy_syscall};
-    use starknet::{get_caller_address, get_block_timestamp};
+    use starknet::event::EventEmitter;
+    use starknet::storage::{
+        Map, StoragePathEntry, StoragePointerReadAccess, StoragePointerWriteAccess,
+    };
+    use starknet::syscalls::deploy_syscall;
+    use starknet::{SyscallResultTrait, get_block_timestamp, get_caller_address};
+    use super::{ContractAddress, DAO, DAOCreationState, IDaoBuilder};
 
     component!(path: OwnableComponent, storage: ownable, event: OwnableEvent);
 
@@ -77,7 +76,7 @@ pub mod DaoBuilder {
         #[substorage(v0)]
         pub ownable: OwnableComponent::Storage,
         pub core_hash: ClassHash,
-        pub deployed_daos: Map::<ContractAddress, DAO>, //map address of a dao to the dao properties
+        pub deployed_daos: Map<ContractAddress, DAO>, //map address of a dao to the dao properties
         pub dao_count: u32,
         pub dao_creation_state: DAOCreationState,
     }
@@ -222,7 +221,7 @@ pub mod DaoBuilder {
         // admin of the DAO can call this function.
         fn update_core_class_hash(
             ref self: ContractState, class_hash: ClassHash, dao_address: ContractAddress,
-        ) {// TODO:
+        ) { // TODO:
         // Use openzeppelin upgradeable component inside the core, and use dispatcher mechanism
         // to call it from here
         }

--- a/contract/tests/test_contract.cairo
+++ b/contract/tests/test_contract.cairo
@@ -12,32 +12,6 @@ use contract::dao_builder::{
 };
 use DaoBuilder::DAODeployed;
 use contract::dao_core::{IDaoCoreDispatcher, IDaoCoreDispatcherTrait};
-// use contract::dao_core::{IDaoCore, IDaoCoreDispatcher, IDaoCoreDispatcherTrait};
-
-fn owner() -> ContractAddress {
-    1.try_into().unwrap()
-}
-
-fn setup() -> ContractAddress {
-    let declare_result = declare("DaoBuilder");
-    let core_class_hash = declare("DaoCore").unwrap().contract_class().class_hash;
-
-    assert(declare_result.is_ok(), 'dao-builder declaration failed');
-
-    let contract_class = declare_result.unwrap().contract_class();
-
-    let mut calldata = array![];
-
-    core_class_hash.serialize(ref calldata);
-    owner().serialize(ref calldata);
-
-    let deploy_result = contract_class.deploy(@calldata);
-
-    assert(deploy_result.is_ok(), 'contract deployment failed');
-
-    let (contract_address, _) = deploy_result.unwrap();
-    contract_address
-}
 
 fn setup_dao_builder() -> (IDaoBuilderDispatcher, ContractAddress, ContractAddress, u64) {
     let owner: ContractAddress = 'owner'.try_into().unwrap();
@@ -110,18 +84,6 @@ fn test_dao_deployed_event_emission() {
     ];
     spy.assert_emitted(@expected_events);
     stop_cheat_caller_address(dao_builder.contract_address);
-}
-
-#[test]
-fn test_create_dao() {
-    let dao_builder = setup();
-
-    let dispatcher = IDaoBuilderDispatcher { contract_address: dao_builder };
-
-    let _ = dispatcher.create_dao('My DAO', 'Test DAO', '10', '1234');
-
-    let dao_count = dispatcher.get_dao_count();
-    assert(dao_count == 1, 'Invalid dao count');
 }
 
 #[test]

--- a/contract/tests/test_dao_builder_constructor.cairo
+++ b/contract/tests/test_dao_builder_constructor.cairo
@@ -1,0 +1,79 @@
+use contract::dao_builder::{DAOCreationState, IDaoBuilderDispatcher, IDaoBuilderDispatcherTrait};
+use snforge_std::{
+    ContractClassTrait, DeclareResultTrait, declare, start_cheat_caller_address,
+    stop_cheat_caller_address,
+};
+use starknet::ContractAddress;
+// use contract::dao_core::{IDaoCore, IDaoCoreDispatcher, IDaoCoreDispatcherTrait};
+
+fn owner() -> ContractAddress {
+    1.try_into().unwrap()
+}
+
+fn setup() -> ContractAddress {
+    let declare_result = declare("DaoBuilder");
+    let core_class_hash = declare("DaoCore").unwrap().contract_class().class_hash;
+
+    assert(declare_result.is_ok(), 'dao-builder declaration failed');
+
+    let contract_class = declare_result.unwrap().contract_class();
+
+    let mut calldata = array![];
+
+    core_class_hash.serialize(ref calldata);
+    owner().serialize(ref calldata);
+
+    let deploy_result = contract_class.deploy(@calldata);
+
+    assert(deploy_result.is_ok(), 'contract deployment failed');
+
+    let (contract_address, _) = deploy_result.unwrap();
+    contract_address
+}
+
+#[test]
+fn test_dao_builder_constructor() {
+    let dao_builder = setup();
+
+    let core_class_hash = declare("DaoCore").unwrap().contract_class().class_hash;
+
+    let dispatcher = IDaoBuilderDispatcher { contract_address: dao_builder };
+
+    start_cheat_caller_address(dao_builder, owner());
+
+    let dao_count = dispatcher.get_dao_count();
+    let dao_creation_state = dispatcher.get_dao_creation_state();
+    let core_hash = dispatcher.get_core_hash();
+    let current_owner = dispatcher.get_owner();
+
+    assert(dao_creation_state == DAOCreationState::CREATIONRESUMED, 'Invalid dao creation state');
+    assert(dao_count == 0, 'Invalid dao count');
+    assert(current_owner == owner(), 'Invalid owner');
+    assert(core_hash == *core_class_hash, 'Invalid core hash');
+
+    stop_cheat_caller_address(dao_builder);
+}
+
+#[test]
+#[should_panic(expected: 'Caller is not the owner')]
+fn test_dao_builder_constructor_must_panic() {
+    let dao_builder = setup();
+
+    let dao_core_class_hash_expected = declare("DaoCore").unwrap().contract_class().class_hash;
+
+    let dispatcher = IDaoBuilderDispatcher { contract_address: dao_builder };
+
+    start_cheat_caller_address(dao_builder, 2.try_into().unwrap());
+
+    let dao_count = dispatcher.get_dao_count();
+    let dao_creation_state = dispatcher.get_dao_creation_state();
+    let core_hash = dispatcher.get_core_hash();
+    let current_owner = dispatcher.get_owner();
+
+    assert(dao_creation_state == DAOCreationState::CREATIONRESUMED, 'Invalid dao creation state');
+    assert(dao_count == 0, 'Invalid dao count');
+    assert(current_owner == owner(), 'Invalid owner');
+    assert(core_hash == *dao_core_class_hash_expected, 'Invalid core hash');
+
+    stop_cheat_caller_address(dao_builder);
+}

--- a/contract/tests/test_dao_builder_get_dao.cairo
+++ b/contract/tests/test_dao_builder_get_dao.cairo
@@ -1,0 +1,103 @@
+use contract::dao_builder::{IDaoBuilderDispatcher, IDaoBuilderDispatcherTrait};
+use snforge_std::{
+    ContractClassTrait, DeclareResultTrait, declare, start_cheat_caller_address,
+    stop_cheat_caller_address,
+};
+use starknet::{ContractAddress, get_block_timestamp};
+
+fn owner() -> ContractAddress {
+    1.try_into().unwrap()
+}
+
+fn setup() -> ContractAddress {
+    let declare_result = declare("DaoBuilder");
+    let core_class_hash = declare("DaoCore").unwrap().contract_class().class_hash;
+
+    assert(declare_result.is_ok(), 'dao-builder declaration failed');
+
+    let contract_class = declare_result.unwrap().contract_class();
+
+    let mut calldata = array![];
+
+    core_class_hash.serialize(ref calldata);
+    owner().serialize(ref calldata);
+
+    let deploy_result = contract_class.deploy(@calldata);
+
+    assert(deploy_result.is_ok(), 'contract deployment failed');
+
+    let (contract_address, _) = deploy_result.unwrap();
+    contract_address
+}
+
+#[test]
+fn test_dao_builder_get_dao_count() {
+    let dao_builder = setup();
+
+    let dispatcher = IDaoBuilderDispatcher { contract_address: dao_builder };
+
+    start_cheat_caller_address(dao_builder, owner());
+
+    let dao_count = dispatcher.get_dao_count();
+
+    assert(dao_count == 0, 'Invalid dao count');
+
+    let _ = dispatcher.create_dao(
+        'Test DAO 1',
+        'TD1',
+        'Description1',
+        'TD1',
+    );
+
+    let dao_count = dispatcher.get_dao_count();
+
+    assert(dao_count == 1, 'Invalid dao count');
+
+    let _ = dispatcher.create_dao(
+        'Test DAO 2',
+        'TD2',
+        'Description2',
+        'TD2',
+    );
+
+    let dao_count = dispatcher.get_dao_count();
+
+    assert(dao_count == 2, 'Invalid dao count');
+
+    stop_cheat_caller_address(dao_builder);
+}
+
+#[test]
+fn test_dao_builder_get_dao_by_address() {
+    let dao_builder = setup();
+
+    let dispatcher = IDaoBuilderDispatcher { contract_address: dao_builder };
+
+    start_cheat_caller_address(dao_builder, 2.try_into().unwrap());
+
+    let empty_dao = dispatcher.get_dao_by_address(0.try_into().unwrap());
+    assert(empty_dao.index == 0, 'Invalid dao index');
+    assert(empty_dao.address == 0.try_into().unwrap(), 'Invalid dao address');
+    assert(empty_dao.deployer == 0.try_into().unwrap(), 'Invalid dao deployer');
+    assert(empty_dao.deployed_at == 0, 'Invalid dao deployed at');
+
+    let dao_count = dispatcher.get_dao_count();
+
+    assert(dao_count == 0, 'Invalid dao count');
+
+    let new_dao = dispatcher.create_dao(
+        'Test DAO 1',
+        'TD1',
+        'Description1',
+        'TD1',
+    );
+
+    let dao_by_address = dispatcher.get_dao_by_address(new_dao);
+
+    assert(dao_by_address.index == 0, 'Invalid dao index');
+    assert(dao_by_address.address == new_dao, 'Invalid dao address');
+    assert(dao_by_address.deployer == 2.try_into().unwrap(), 'Invalid dao deployer');
+    assert(dao_by_address.deployed_at == get_block_timestamp(), 'Invalid dao deployed at');
+
+    stop_cheat_caller_address(dao_builder);
+}


### PR DESCRIPTION
# Description

Add comprehensive tests for DAO retrieval functionality in the DAO Builder contract.

## Changes Made

- [x] Added test for DAO count tracking (`test_dao_builder_get_dao_count`)
- [x] Added test for DAO retrieval by address (`test_dao_builder_get_dao_by_address`)
- [x] Implemented test setup with proper contract deployment and caller authentication
- [x] Added validation for DAO properties (index, address, deployer, deployed_at)

## Checklist

- [x] I have tested my changes locally.
- [ ] I have updated the documentation (if applicable).
- [x] I have added/updated unit tests (if applicable).
- [x] My code follows the project's coding standards.
- [ ] My changes do not introduce new warnings or errors.

## Related Issues

- Fixes #100 

## Additional Context

These tests ensure the DAO Builder contract correctly tracks and retrieves DAO information, covering both empty state scenarios and populated DAOs with proper metadata validation.