### PR TITLE
feat: Units-and-integration-tests-for-pause-creation-and-resume-creation-functions-99

### DIFF
--- a/contract/src/dao_core.cairo
+++ b/contract/src/dao_core.cairo
@@ -102,7 +102,7 @@ pub mod DaoCore {
         name: felt252,
         // Optional:  DAO description
         description: felt252,
-        // Optional:  DAO quorum 
+        // Optional:  DAO quorum
         quorum: felt252,
         // Member counts for each tier.
         admin_count: u32,
@@ -111,7 +111,13 @@ pub mod DaoCore {
     // Constructor for the DAO Core contract.
     // Initializes the owner (Floor 1) and the DAO name.
     #[constructor]
-    fn constructor(ref self: ContractState, owner: ContractAddress, name: felt252, description: felt252, quorum: felt252) {
+    fn constructor(
+        ref self: ContractState,
+        owner: ContractAddress,
+        name: felt252,
+        description: felt252,
+        quorum: felt252,
+    ) {
         assert!(!owner.is_zero(), "Owner address cannot be zero");
         self.owner.write(owner);
         self.name.write(name);

--- a/contract/tests/test_contract.cairo
+++ b/contract/tests/test_contract.cairo
@@ -1,23 +1,22 @@
 use starknet::ContractAddress;
 use snforge_std::{
     declare, ContractClassTrait, DeclareResultTrait, start_cheat_caller_address,
-    stop_cheat_caller_address, start_cheat_block_timestamp,
-    spy_events, EventSpyAssertionsTrait
+    stop_cheat_caller_address, start_cheat_block_timestamp, spy_events, EventSpyAssertionsTrait,
 };
 use core::num::traits::Zero;
 use core::serde::Serde;
 
 use contract::dao_builder::{
-    IDaoBuilderDispatcher, IDaoBuilderDispatcherTrait, DaoBuilder
+    IDaoBuilderDispatcher, IDaoBuilderDispatcherTrait, DaoBuilder, DAOCreationState,
 };
-use DaoBuilder::DAODeployed;
+use DaoBuilder::{DAODeployed};
 use contract::dao_core::{IDaoCoreDispatcher, IDaoCoreDispatcherTrait};
 
 fn setup_dao_builder() -> (IDaoBuilderDispatcher, ContractAddress, ContractAddress, u64) {
     let owner: ContractAddress = 'owner'.try_into().unwrap();
     let deployer: ContractAddress = 'deployer'.try_into().unwrap();
     let initial_timestamp: u64 = 1000;
-    
+
     // Declare DaoCore and DaoBuilder
     let dao_core_class = declare("DaoCore").unwrap().contract_class();
     let dao_core_class_hash = dao_core_class.class_hash;
@@ -30,7 +29,7 @@ fn setup_dao_builder() -> (IDaoBuilderDispatcher, ContractAddress, ContractAddre
 
     // Set timestamp
     start_cheat_block_timestamp(dao_builder_address, initial_timestamp);
-    
+
     (dao_builder, owner, deployer, initial_timestamp)
 }
 
@@ -40,7 +39,7 @@ fn test_create_dao_success() {
     // Setup
     let (dao_builder, _, deployer, _) = setup_dao_builder();
     start_cheat_caller_address(dao_builder.contract_address, deployer);
-    
+
     // Test data
     let dao_name: felt252 = 'TestDAO';
     let dao_description: felt252 = 'Test DAO Description';
@@ -59,7 +58,7 @@ fn test_dao_deployed_event_emission() {
     let (dao_builder, _, deployer, initial_timestamp) = setup_dao_builder();
     start_cheat_caller_address(dao_builder.contract_address, deployer);
     let mut spy = spy_events();
-    
+
     // Test data
     let dao_name: felt252 = 'TestDAO';
     let dao_description: felt252 = 'Test DAO Description';
@@ -68,7 +67,7 @@ fn test_dao_deployed_event_emission() {
 
     // Test
     let dao_address = dao_builder.create_dao(dao_name, dao_description, dao_quorum, salt);
-    
+
     let expected_events = array![
         (
             dao_builder.contract_address,
@@ -78,9 +77,9 @@ fn test_dao_deployed_event_emission() {
                     deployer: deployer,
                     deployed_at: initial_timestamp,
                     dao_address: dao_address,
-                }
-            )
-        )
+                },
+            ),
+        ),
     ];
     spy.assert_emitted(@expected_events);
     stop_cheat_caller_address(dao_builder.contract_address);
@@ -91,7 +90,7 @@ fn test_dao_count_increments_after_creation() {
     // Setup
     let (dao_builder, _, deployer, _) = setup_dao_builder();
     start_cheat_caller_address(dao_builder.contract_address, deployer);
-    
+
     // Test data
     let dao_name: felt252 = 'TestDAO';
     let dao_description: felt252 = 'Test DAO Description';
@@ -102,7 +101,7 @@ fn test_dao_count_increments_after_creation() {
     let initial_dao_count = dao_builder.get_dao_count();
     dao_builder.create_dao(dao_name, dao_description, dao_quorum, salt);
     let new_dao_count = dao_builder.get_dao_count();
-    
+
     assert(new_dao_count == initial_dao_count + 1, 'DAO count should increment');
     stop_cheat_caller_address(dao_builder.contract_address);
 }
@@ -112,7 +111,7 @@ fn test_dao_metadata_retrieval() {
     // Setup
     let (dao_builder, _, deployer, initial_timestamp) = setup_dao_builder();
     start_cheat_caller_address(dao_builder.contract_address, deployer);
-    
+
     // Test data
     let dao_name: felt252 = 'TestDAO';
     let dao_description: felt252 = 'Test DAO Description';
@@ -122,7 +121,7 @@ fn test_dao_metadata_retrieval() {
     // Test
     let dao_address = dao_builder.create_dao(dao_name, dao_description, dao_quorum, salt);
     let retrieved_dao = dao_builder.get_dao_by_address(dao_address);
-    
+
     assert(retrieved_dao.index == 0, 'DAO index should be 0');
     assert(retrieved_dao.address == dao_address, 'DAO address should match');
     assert(retrieved_dao.deployer == deployer, 'DAO deployer should match');
@@ -135,7 +134,7 @@ fn test_dao_core_initialization() {
     // Setup
     let (dao_builder, _, deployer, _) = setup_dao_builder();
     start_cheat_caller_address(dao_builder.contract_address, deployer);
-    
+
     // Test data
     let dao_name: felt252 = 'TestDAO';
     let dao_description: felt252 = 'Test DAO Description';
@@ -160,15 +159,162 @@ fn test_dao_core_initialization() {
 fn test_create_dao_while_paused_fails() {
     // Setup
     let (dao_builder, owner, deployer, _) = setup_dao_builder();
-    
+
     // First pause creation
     start_cheat_caller_address(dao_builder.contract_address, owner);
     dao_builder.pause_creation();
     stop_cheat_caller_address(dao_builder.contract_address);
-    
+
     // Then try to create DAO as deployer (should panic)
     start_cheat_caller_address(dao_builder.contract_address, deployer);
     dao_builder.create_dao('AnotherDAO', 'Another Description', 60, 'different_salt');
+}
 
-    
+#[test]
+fn test_pause_creation_success() {
+    // Setup
+    let (dao_builder, owner, _, _) = setup_dao_builder();
+    start_cheat_caller_address(dao_builder.contract_address, owner);
+
+    // Test
+    let result = dao_builder.pause_creation();
+    assert(result == true, 'Pause creation should be true');
+
+    let state = dao_builder.get_dao_creation_state();
+    assert(state == DAOCreationState::CREATIONPAUSED, 'State should be paused');
+
+    stop_cheat_caller_address(dao_builder.contract_address);
+}
+
+#[test]
+fn test_pause_creation_emits_event() {
+    // Setup
+    let (dao_builder, owner, _, initial_timestamp) = setup_dao_builder();
+    start_cheat_caller_address(dao_builder.contract_address, owner);
+    let mut spy = spy_events();
+
+    // Test
+    dao_builder.pause_creation();
+
+    let expected_events = array![
+        (
+            dao_builder.contract_address,
+            DaoBuilder::Event::CreationStateChanged(
+                DaoBuilder::CreationStateChanged {
+                    new_state: DAOCreationState::CREATIONPAUSED,
+                    state_changed_at: initial_timestamp,
+                },
+            ),
+        ),
+    ];
+    spy.assert_emitted(@expected_events);
+    stop_cheat_caller_address(dao_builder.contract_address);
+}
+
+#[test]
+#[should_panic(expected: ('Caller is not the owner',))]
+fn test_pause_creation_non_owner_fails() {
+    // Setup
+    let (dao_builder, _, deployer, _) = setup_dao_builder();
+    start_cheat_caller_address(dao_builder.contract_address, deployer);
+
+    // Test - should panic
+    dao_builder.pause_creation();
+}
+
+#[test]
+#[should_panic(expected: ('Creation already paused',))]
+fn test_pause_creation_already_paused_fails() {
+    // Setup
+    let (dao_builder, owner, _, _) = setup_dao_builder();
+    start_cheat_caller_address(dao_builder.contract_address, owner);
+
+    // First pause
+    dao_builder.pause_creation();
+
+    // Try to pause again - should panic
+    dao_builder.pause_creation();
+}
+
+#[test]
+fn test_resume_creation_success() {
+    // Setup
+    let (dao_builder, owner, _, _) = setup_dao_builder();
+    start_cheat_caller_address(dao_builder.contract_address, owner);
+
+    // First pause
+    dao_builder.pause_creation();
+
+    // Test resume
+    let result = dao_builder.resume_creation();
+    assert(result == true, 'Resume creation should be true');
+
+    let state = dao_builder.get_dao_creation_state();
+    assert(state == DAOCreationState::CREATIONRESUMED, 'State should be resumed');
+
+    stop_cheat_caller_address(dao_builder.contract_address);
+}
+
+#[test]
+fn test_resume_creation_emits_event() {
+    // Setup
+    let (dao_builder, owner, _, initial_timestamp) = setup_dao_builder();
+    start_cheat_caller_address(dao_builder.contract_address, owner);
+    let mut spy = spy_events();
+
+    // First pause
+    dao_builder.pause_creation();
+
+    // Test resume
+    dao_builder.resume_creation();
+
+    let expected_events = array![
+        (
+            dao_builder.contract_address,
+            DaoBuilder::Event::CreationStateChanged(
+                DaoBuilder::CreationStateChanged {
+                    new_state: DAOCreationState::CREATIONPAUSED,
+                    state_changed_at: initial_timestamp,
+                },
+            ),
+        ),
+        (
+            dao_builder.contract_address,
+            DaoBuilder::Event::CreationStateChanged(
+                DaoBuilder::CreationStateChanged {
+                    new_state: DAOCreationState::CREATIONRESUMED,
+                    state_changed_at: initial_timestamp,
+                },
+            ),
+        ),
+    ];
+    spy.assert_emitted(@expected_events);
+    stop_cheat_caller_address(dao_builder.contract_address);
+}
+
+#[test]
+#[should_panic(expected: ('Caller is not the owner',))]
+fn test_resume_creation_non_owner_fails() {
+    // Setup
+    let (dao_builder, owner, deployer, _) = setup_dao_builder();
+
+    // First pause as owner
+    start_cheat_caller_address(dao_builder.contract_address, owner);
+    dao_builder.pause_creation();
+    stop_cheat_caller_address(dao_builder.contract_address);
+
+    // Try to resume as non-owner - should panic
+    start_cheat_caller_address(dao_builder.contract_address, deployer);
+    dao_builder.resume_creation();
+}
+
+#[test]
+#[should_panic(expected: ('Creation already resumed',))]
+fn test_resume_creation_already_resumed_fails() {
+    // Setup
+    let (dao_builder, owner, _, _) = setup_dao_builder();
+    start_cheat_caller_address(dao_builder.contract_address, owner);
+
+    // Try to resume when already resumed - should panic
+    dao_builder.resume_creation();
 }

--- a/contract/tests/test_dao_builder_get_dao.cairo
+++ b/contract/tests/test_dao_builder_get_dao.cairo
@@ -42,23 +42,13 @@ fn test_dao_builder_get_dao_count() {
 
     assert(dao_count == 0, 'Invalid dao count');
 
-    let _ = dispatcher.create_dao(
-        'Test DAO 1',
-        'TD1',
-        'Description1',
-        'TD1',
-    );
+    let _ = dispatcher.create_dao('Test DAO 1', 'TD1', 'Description1', 'TD1');
 
     let dao_count = dispatcher.get_dao_count();
 
     assert(dao_count == 1, 'Invalid dao count');
 
-    let _ = dispatcher.create_dao(
-        'Test DAO 2',
-        'TD2',
-        'Description2',
-        'TD2',
-    );
+    let _ = dispatcher.create_dao('Test DAO 2', 'TD2', 'Description2', 'TD2');
 
     let dao_count = dispatcher.get_dao_count();
 
@@ -85,12 +75,7 @@ fn test_dao_builder_get_dao_by_address() {
 
     assert(dao_count == 0, 'Invalid dao count');
 
-    let new_dao = dispatcher.create_dao(
-        'Test DAO 1',
-        'TD1',
-        'Description1',
-        'TD1',
-    );
+    let new_dao = dispatcher.create_dao('Test DAO 1', 'TD1', 'Description1', 'TD1');
 
     let dao_by_address = dispatcher.get_dao_by_address(new_dao);
 


### PR DESCRIPTION
## Description

This PR implements comprehensive unit and integration testing for the `pause_creation` and `resume_creation` functionality in the DAO Builder contract system. This feature allows the contract owner to temporarily halt and resume DAO creation operations, providing administrative control over the DAO deployment process.

## Changes Made
Added the following comprehensive Tests 
* `test_pause_creation_success` - Tests successful pause operation and state update.
* `test_resume_creation_success` - Tests successful resume operation after pause.
* `test_pause_creation_emits_event` - Validates CreationStateChanged event emission on pause.
* `test_resume_creation_emits_event` - Validates CreationStateChanged event emission on resume.
* `test_pause_creation_non_owner_fails` - Ensures non-owners cannot pause creation.
* `test_resume_creation_non_owner_fails` - Ensures non-owners cannot resume creation.
* `test_pause_creation_already_paused_fails` - Prevents duplicate pause operations.
* `test_resume_creation_already_resumed_fails` - Prevents duplicate resume operations.
* `test_create_dao_while_paused_fails` - Validates DAO creation is blocked when paused.

## Checklist
- [✅] I have tested my changes locally.
- [✅] I have updated the documentation (if applicable).
- [✅] I have added/updated unit tests (if applicable).
- [✅] My code follows the project's coding standards.
- [✅] My changes do not introduce new warnings or errors.

## Related Issues

- Fixes #99 
