### PR TITLE
Feature/custom factor module

### DIFF
--- a/contract/.tool-versions
+++ b/contract/.tool-versions
@@ -1,1 +1,2 @@
-scarb 2.10.1
+scarb 2.11.4
+starknet-foundry 0.38.0

--- a/contract/Scarb.toml
+++ b/contract/Scarb.toml
@@ -6,7 +6,7 @@ edition = "2024_07"
 # See more keys and their definitions at https://docs.swmansion.com/scarb/docs/reference/manifest.html
 
 [dependencies]
-starknet = "2.10.1"
+starknet = "2.11.4"
 openzeppelin = "1.0.0"
 
 [dev-dependencies]
@@ -37,7 +37,7 @@ test-runner = { path = "tests" }
 
 # [[tool.snforge.fork]]
 # name = "SOME_SECOND_NAME"
-# url = "http://your.second.rpc.url"                         
+# url = "http://your.second.rpc.url"
 # block_id.number = "123"                                    # Block to fork from (block number)
 
 # [[tool.snforge.fork]]

--- a/contract/src/CustomFactor.cairo
+++ b/contract/src/CustomFactor.cairo
@@ -1,0 +1,112 @@
+use starknet::ContractAddress;
+
+#[starknet::interface]
+pub trait IVoteWeight<TContractState> {
+    fn set_weight(ref self: TContractState, account: ContractAddress, weight: u128);
+    fn bulk_set_weights(
+        ref self: TContractState, accounts: Span<ContractAddress>, weights: Span<u128>,
+    );
+    fn get_weight(self: @TContractState, voter: ContractAddress) -> u128;
+}
+
+#[starknet::contract]
+pub mod CustomFactor {
+    use core::num::traits::Zero;
+    use openzeppelin::access::accesscontrol::{AccessControlComponent, DEFAULT_ADMIN_ROLE};
+    use openzeppelin::introspection::src5::SRC5Component;
+    use starknet::ContractAddress;
+    use starknet::storage::{
+        Map, StoragePathEntry, StoragePointerReadAccess, StoragePointerWriteAccess,
+    };
+
+    component!(path: AccessControlComponent, storage: accesscontrol, event: AccessControlEvent);
+    component!(path: SRC5Component, storage: src5, event: SRC5Event);
+
+    // AccessControl
+    #[abi(embed_v0)]
+    impl AccessControlImpl =
+        AccessControlComponent::AccessControlImpl<ContractState>;
+    impl AccessControlInternalImpl = AccessControlComponent::InternalImpl<ContractState>;
+
+    // SRC5
+    #[abi(embed_v0)]
+    impl SRC5Impl = SRC5Component::SRC5Impl<ContractState>;
+
+    #[storage]
+    struct Storage {
+        #[substorage(v0)]
+        accesscontrol: AccessControlComponent::Storage,
+        #[substorage(v0)]
+        src5: SRC5Component::Storage,
+        weights: Map<ContractAddress, u128>,
+    }
+
+    #[event]
+    #[derive(Drop, starknet::Event)]
+    pub enum Event {
+        #[flat]
+        AccessControlEvent: AccessControlComponent::Event,
+        #[flat]
+        SRC5Event: SRC5Component::Event,
+        WeightSet: WeightSet,
+    }
+
+    #[derive(Drop, starknet::Event)]
+    pub struct WeightSet {
+        pub account: ContractAddress,
+        pub weight: u128,
+    }
+
+    #[abi(embed_v0)]
+    impl VoteWeightImpl of super::IVoteWeight<ContractState> {
+        fn set_weight(ref self: ContractState, account: ContractAddress, weight: u128) {
+            // Admin only
+            self.accesscontrol.assert_only_role(DEFAULT_ADMIN_ROLE);
+
+            // Ensure the account is not zero
+            assert(!account.is_zero(), 'Account cannot be zero');
+
+            self.weights.entry(account).write(weight);
+            self.emit(Event::WeightSet(WeightSet { account, weight }));
+        }
+
+        fn bulk_set_weights(
+            ref self: ContractState, accounts: Span<ContractAddress>, weights: Span<u128>,
+        ) {
+            // Admin only
+            self.accesscontrol.assert_only_role(DEFAULT_ADMIN_ROLE);
+
+            let accounts_len = accounts.len();
+            let weights_len = weights.len();
+
+            // Ensure the accounts and weights are not empty
+            assert(accounts_len > 0, 'Accounts cannot be empty');
+            assert(weights_len > 0, 'Weights cannot be empty');
+
+            // Ensure both spans have the same length
+            assert(accounts_len == weights_len, 'Length mismatch');
+
+            for i in 0..accounts_len {
+                let account = *accounts[i];
+                let weight = *weights[i];
+
+                // Ensure the account is not zero
+                assert(!account.is_zero(), 'Account cannot be zero');
+
+                self.weights.entry(account).write(weight);
+                self.emit(Event::WeightSet(WeightSet { account, weight }));
+            }
+        }
+
+        fn get_weight(self: @ContractState, voter: ContractAddress) -> u128 {
+            self.weights.entry(voter).read()
+        }
+    }
+
+    #[constructor]
+    fn constructor(ref self: ContractState, admin: ContractAddress) {
+        assert!(!admin.is_zero(), "Admin address cannot be zero");
+        self.accesscontrol.initializer();
+        self.accesscontrol._grant_role(DEFAULT_ADMIN_ROLE, admin);
+    }
+}

--- a/contract/src/lib.cairo
+++ b/contract/src/lib.cairo
@@ -1,4 +1,5 @@
 //mod governance;
+pub mod CustomFactor;
 pub mod dao_builder;
 pub mod dao_core;
 pub mod dao_treasury;

--- a/contract/tests/test_custom_factor.cairo
+++ b/contract/tests/test_custom_factor.cairo
@@ -1,0 +1,92 @@
+use contract::CustomFactor::{CustomFactor, IVoteWeightDispatcher, IVoteWeightDispatcherTrait};
+use snforge_std::{
+    ContractClassTrait, DeclareResultTrait, EventSpyAssertionsTrait, declare, spy_events,
+    start_cheat_caller_address, stop_cheat_caller_address,
+};
+use starknet::ContractAddress;
+
+const ADMIN: ContractAddress = 'admin'.try_into().unwrap();
+
+fn deploy_contract(name: ByteArray, calldata: Array<felt252>) -> ContractAddress {
+    let contract = declare(name).unwrap().contract_class();
+    let (contract_address, _) = contract.deploy(@calldata).unwrap();
+    contract_address
+}
+
+fn setup() -> IVoteWeightDispatcher {
+    let mut calldata = array![];
+    ADMIN.serialize(ref calldata);
+    IVoteWeightDispatcher { contract_address: deploy_contract("CustomFactor", calldata) }
+}
+
+#[test]
+fn test_set_vote_weight_by_admin() {
+    let vote_weight = setup();
+    let user1: ContractAddress = 'user1'.try_into().unwrap();
+    let weight = 100;
+
+    start_cheat_caller_address(vote_weight.contract_address, ADMIN);
+    let mut spy = spy_events();
+    vote_weight.set_weight(user1, weight);
+    stop_cheat_caller_address(vote_weight.contract_address);
+
+    // Ensure the weight is properly set
+    assert(vote_weight.get_weight(user1) == weight, 'Weight not set correctly');
+
+    // Ensure an event is emitted
+    let expected_event = CustomFactor::Event::WeightSet(
+        CustomFactor::WeightSet { account: user1, weight },
+    );
+    spy.assert_emitted(@array![(vote_weight.contract_address, expected_event)]);
+}
+
+#[test]
+#[should_panic(expected: 'Caller is missing role')]
+fn test_set_vote_weight_by_non_admin() {
+    let vote_weight = setup();
+    let user1: ContractAddress = 'user1'.try_into().unwrap();
+
+    vote_weight.set_weight(user1, 100);
+}
+
+#[test]
+#[should_panic(expected: 'Account cannot be zero')]
+fn test_set_vote_weight_for_zero_address() {
+    let vote_weight = setup();
+    let user1: ContractAddress = 0.try_into().unwrap();
+
+    start_cheat_caller_address(vote_weight.contract_address, ADMIN);
+    vote_weight.set_weight(user1, 100);
+    stop_cheat_caller_address(vote_weight.contract_address);
+}
+
+#[test]
+fn test_bulk_set_vote_weight_by_admin() {
+    let vote_weight = setup();
+    let user1: ContractAddress = 'user1'.try_into().unwrap();
+    let user2: ContractAddress = 'user2'.try_into().unwrap();
+    let user3: ContractAddress = 'user3'.try_into().unwrap();
+
+    let users: Span<ContractAddress> = array![user1, user2, user3].span();
+    let weights: Span<u128> = array![100, 200, 300].span();
+
+    start_cheat_caller_address(vote_weight.contract_address, ADMIN);
+    let mut spy = spy_events();
+    vote_weight.bulk_set_weights(users, weights);
+    stop_cheat_caller_address(vote_weight.contract_address);
+
+    // Ensure the weights are properly set
+    assert(vote_weight.get_weight(user1) == 100, 'Weight not set correctly');
+    assert(vote_weight.get_weight(user2) == 200, 'Weight not set correctly');
+    assert(vote_weight.get_weight(user3) == 300, 'Weight not set correctly');
+
+    // Ensure all events are emitted
+    let expected_events = array![
+        CustomFactor::Event::WeightSet(CustomFactor::WeightSet { account: user1, weight: 100 }),
+        CustomFactor::Event::WeightSet(CustomFactor::WeightSet { account: user2, weight: 200 }),
+        CustomFactor::Event::WeightSet(CustomFactor::WeightSet { account: user3, weight: 300 }),
+    ];
+    for expected_event in expected_events {
+        spy.assert_emitted(@array![(vote_weight.contract_address, expected_event)]);
+    }
+}


### PR DESCRIPTION
# Description

Implements the `CustomFactor` module inside `CustomFactor.cairo` allowing DAOs to set voting weights easily. This module provides a flexible weight mapping system with proper admin restrictions using OpenZeppelin's AccessControl.

## Changes Made

- [x] Implemented `IVoteWeight` interface with `set_weight`, `bulk_set_weights`, and `get_weight` functions
- [x] Added `weights: Map<ContractAddress, u128>` storage mapping for vote weight management
- [x] Integrated OpenZeppelin AccessControl for admin-only functions
- [x] Added comprehensive tests 
- [x] Updated Cairo version to 2.11.4 and added starknet-foundry version in .tool-versions to make the existing tests and my own tests compile

## Checklist

- [X] I have tested my changes locally.
- [X] I have added/updated unit tests (if applicable).
- [X] My code follows the project's coding standards.
- [X] My changes do not introduce new warnings or errors.

## Related Issues

- Fixes #116 
