### PR TITLE
Adding new IGovernanceInterface module with its types and conversions

### DIFF
--- a/contract/src/IGovernanceModule.cairo
+++ b/contract/src/IGovernanceModule.cairo
@@ -1,0 +1,52 @@
+use starknet::ContractAddress;
+use super::types::{Action, Proposal};
+
+/// Interface that all governance modules must implement
+/// This ensures modularity and future compatibility across different governance mechanisms
+#[starknet::interface]
+pub trait IGovernanceModule<TContractState> {
+    /// Creates a new proposal in the governance system
+    ///
+    /// # Arguments
+    /// * `proposer` - The address of the account creating the proposal
+    /// * `proposal_cid` - Content ID pointing to the proposal metadata (IPFS hash)
+    /// * `actions` - Span of actions to be executed if the proposal passes
+    fn create_proposal(
+        ref self: TContractState,
+        proposer: ContractAddress,
+        proposal_cid: felt252,
+        actions: Span<Action>,
+    );
+
+    /// Casts a vote on a specific proposal
+    ///
+    /// # Arguments
+    /// * `voter` - The address of the account casting the vote
+    /// * `proposal_id` - Unique identifier of the proposal
+    /// * `vote` - Vote type: 0 = Against, 1 = For, 2 = Abstain
+    fn cast_vote(ref self: TContractState, voter: ContractAddress, proposal_id: u256, vote: u8);
+
+    /// Executes a proposal that has passed voting
+    ///
+    /// # Arguments
+    /// * `proposal_id` - Unique identifier of the proposal to execute
+    fn execute_proposal(ref self: TContractState, proposal_id: u256);
+
+    /// Retrieves the full proposal data
+    ///
+    /// # Arguments
+    /// * `proposal_id` - Unique identifier of the proposal
+    ///
+    /// # Returns
+    /// Complete proposal struct with all metadata and current state
+    fn get_proposal(self: @TContractState, proposal_id: u256) -> Proposal;
+
+    /// Gets the current state of a proposal
+    ///
+    /// # Arguments
+    /// * `proposal_id` - Unique identifier of the proposal
+    ///
+    /// # Returns
+    /// Current state as u8: 0=Pending, 1=Active, 2=Succeeded, 3=Defeated, 4=Executed
+    fn get_proposal_state(self: @TContractState, proposal_id: u256) -> u8;
+}

--- a/contract/src/lib.cairo
+++ b/contract/src/lib.cairo
@@ -1,4 +1,6 @@
 //mod governance;
+pub mod IGovernanceModule;
 pub mod dao_builder;
 pub mod dao_core;
 pub mod dao_treasury;
+pub mod types;

--- a/contract/src/types.cairo
+++ b/contract/src/types.cairo
@@ -1,0 +1,101 @@
+use starknet::ContractAddress;
+
+/// Example usage of ProposalState conversions and interface interactions:
+///
+/// ```cairo
+/// // The interface returns u8 directly from get_proposal_state()
+/// let state_u8: u8 = governance_module.get_proposal_state(proposal_id); // Returns 0-4
+///
+/// // Convert u8 to ProposalState enum for pattern matching
+/// let state_option: Option<ProposalState> = state_u8.try_into();
+/// match state_option {
+///     Option::Some(ProposalState::Active) => {
+///         // Handle active proposal
+///     },
+///     Option::Some(ProposalState::Succeeded) => {
+///         // Handle succeeded proposal
+///     },
+///     Option::None => {
+///         // Invalid state value
+///     }
+/// }
+///
+/// // Convert ProposalState to u8 when storing in Proposal struct
+/// let state = ProposalState::Active;
+/// let proposal = Proposal {
+///     // ... other fields ...
+///     state: state.into(), // Converts to u8 (1)
+///     // ... other fields ...
+/// };
+/// ```
+
+/// Represents the state of a governance proposal
+#[derive(Copy, Drop, Serde, starknet::Store, PartialEq)]
+pub enum ProposalState {
+    /// Proposal is waiting to become active
+    Pending,
+    /// Proposal is active for voting
+    Active,
+    /// Proposal succeeded and can be executed
+    Succeeded,
+    /// Proposal was defeated in voting
+    Defeated,
+    /// Proposal was executed
+    #[default]
+    Executed,
+}
+
+/// Implementation to convert ProposalState to u8
+impl ProposalStateIntoU8 of Into<ProposalState, u8> {
+    fn into(self: ProposalState) -> u8 {
+        match self {
+            ProposalState::Pending => 0,
+            ProposalState::Active => 1,
+            ProposalState::Succeeded => 2,
+            ProposalState::Defeated => 3,
+            ProposalState::Executed => 4,
+        }
+    }
+}
+
+/// Implementation to convert u8 to ProposalState
+impl U8TryIntoProposalState of TryInto<u8, ProposalState> {
+    fn try_into(self: u8) -> Option<ProposalState> {
+        match self {
+            0 => Option::Some(ProposalState::Pending),
+            1 => Option::Some(ProposalState::Active),
+            2 => Option::Some(ProposalState::Succeeded),
+            3 => Option::Some(ProposalState::Defeated),
+            4 => Option::Some(ProposalState::Executed),
+            _ => Option::None,
+        }
+    }
+}
+
+/// Represents an action to be executed as part of a proposal
+#[derive(Drop, Serde)]
+pub struct Action {
+    /// The target contract address to call
+    pub target: ContractAddress,
+    /// The selector of the function to call
+    pub selector: felt252,
+    /// The calldata to pass to the function
+    pub calldata: Array<felt252>,
+}
+
+/// Represents a governance proposal
+#[derive(Drop, Serde)]
+pub struct Proposal {
+    pub id: u256,
+    pub proposer: ContractAddress,
+    pub cid: felt252,
+    pub vote_start_time: u64,
+    pub vote_end_time: u64,
+    pub for_votes: u256,
+    pub against_votes: u256,
+    pub abstain_votes: u256,
+    pub state: u8, // 0=Pending, 1=Active, 2=Succeeded, 3=Defeated, 4=Executed
+    pub is_executed: bool,
+    pub actions: Span<Action>,
+}
+


### PR DESCRIPTION
# Description

Implements the IGovernanceModule interface as specified in issue #83 to ensure modularity and future compatibility across different governance mechanisms on the SocialSphere platform.

## Changes Made

- [x] Created `IGovernanceModule.cairo` interface with all required function signatures
- [x] Defined `ProposalState` enum with bidirectional conversion traits (enum ↔ u8)
- [x] Implemented `Action` and `Proposal` structs in `types.cairo`
- [x] Added comprehensive documentation with usage examples
- [x] Configured proper module exports in `lib.cairo`

## Checklist

- [x] I have tested my changes locally.
- [x] I have updated the documentation (if applicable).
- [ ] I have added/updated unit tests (if applicable).
- [x] My code follows the project's coding standards.
- [x] My changes do not introduce new warnings or errors.

## Related Issues

- Fixes #83

## Additional Context

The interface strictly follows the issue requirements:
- `get_proposal_state()` returns `u8` (0=Pending, 1=Active, 2=Succeeded, 3=Defeated, 4=Executed)
- `create_proposal()` uses `Span<Action>` as specified
- Conversion traits allow seamless work between enum and u8 representations
- All structs are properly serializable for Starknet compatibility